### PR TITLE
Add unit test for unsupported file format in `process_files`

### DIFF
--- a/tests/test_process_files_unsupported_file_format.py
+++ b/tests/test_process_files_unsupported_file_format.py
@@ -1,0 +1,12 @@
+import pytest
+from utils import process_files
+ 
+def test_process_files_unsupported_file_format():
+    files = ["unsupported_file_format.pdf"]  # Unsupported format for process_files
+    api_key = "test_key"
+    model = "llama3-8b-8192"
+    mode = "detailed"
+    provider_name = "groq"
+ 
+    with pytest.raises(Exception, match="Unsupported file format"):
+        process_files(files, api_key, model, mode, token_usage=True, provider_name=provider_name)


### PR DESCRIPTION
**Description:**  
This PR introduces a new unit test, `test_process_files_unsupported_file_format`, to verify that the `process_files` function raises an exception when handling an unsupported file format. Specifically:
- A `.pdf` file, which is not supported by `process_files`, is tested.
- The test ensures that an exception with the message "Unsupported file format" is raised as expected.

**Changes:**  
- Added a test in `test_process_files_unsupported_file_format` to check behavior for unsupported file types.

**Testing:**  
- Used `pytest` to confirm the test correctly catches the exception and verifies the error message.

**Why:**  
This test enhances the robustness of the codebase by ensuring unsupported file formats are properly handled and reported.

Let me know if you’d like further tweaks!